### PR TITLE
fluentd: add optional gzip compression support

### DIFF
--- a/clients/cmd/fluentd/lib/fluent/plugin/out_loki.rb
+++ b/clients/cmd/fluentd/lib/fluent/plugin/out_loki.rb
@@ -20,6 +20,8 @@ require 'fluent/plugin/output'
 require 'net/http'
 require 'yajl'
 require 'time'
+require 'zlib'
+require 'stringio'
 
 module Fluent
   module Plugin
@@ -63,6 +65,9 @@ module Fluent
 
       desc 'Custom HTTP headers'
       config_param :custom_headers, :hash, default: {}
+
+      desc 'Compress HTTP request payload'
+      config_param :compress, :enum, list: %i[gzip], default: nil
 
       desc 'Loki tenant id'
       config_param :tenant, :string, default: nil
@@ -241,7 +246,17 @@ module Fluent
         req.add_field('Content-Type', 'application/json')
         req.add_field('Authorization', "Bearer #{@auth_token_bearer}") unless @auth_token_bearer.nil?
         req.add_field('X-Scope-OrgID', tenant) if tenant
-        req.body = Yajl.dump(body)
+        payload = Yajl.dump(body)
+        if @compress == :gzip
+          req.add_field('Content-Encoding', 'gzip')
+          io = StringIO.new
+          gz = Zlib::GzipWriter.new(io)
+          gz.write(payload)
+          gz.close
+          req.body = io.string
+        else
+          req.body = payload
+        end
         req.basic_auth(@username, @password) if @username
 
         opts = http_request_opts(@uri)

--- a/clients/cmd/fluentd/lib/fluent/plugin/out_loki.rb
+++ b/clients/cmd/fluentd/lib/fluent/plugin/out_loki.rb
@@ -250,9 +250,7 @@ module Fluent
         if @compress == :gzip
           req.add_field('Content-Encoding', 'gzip')
           io = StringIO.new
-          gz = Zlib::GzipWriter.new(io)
-          gz.write(payload)
-          gz.close
+          Zlib::GzipWriter.wrap(io) { |gz| gz.write(payload) }
           req.body = io.string
         else
           req.body = payload

--- a/docs/sources/send-data/fluentd/_index.md
+++ b/docs/sources/send-data/fluentd/_index.md
@@ -257,6 +257,21 @@ A flag to disable server certificate verification. By default the `insecure_tls`
 </match>
 ```
 
+### compress
+
+Enable compression for the HTTP request body. Supported values: `gzip`. Not compressed by default.
+
+```conf
+<match **>
+  @type loki
+
+  url "https://loki"
+  compress gzip
+
+  ...
+</match>
+```
+
 ### Output format
 
 Loki is intended to index and group log streams using only a small set of labels. It is not intended for full-text indexing. When sending logs to Loki the majority of log message will be sent as a single log "line".


### PR DESCRIPTION
## Summary
- add `compress gzip` option to send gzipped payloads from Fluentd to Loki
- document `compress` option in Fluentd client docs

## Testing
- `ruby -c clients/cmd/fluentd/lib/fluent/plugin/out_loki.rb`
- `cd clients/cmd/fluentd && bundle exec rubocop lib/fluent/plugin/out_loki.rb`


------
https://chatgpt.com/codex/tasks/task_b_68abdb0662548321b0b4a277148f5c6b